### PR TITLE
Use prefix (not postfix) char to indicate block form

### DIFF
--- a/doc.dmark
+++ b/doc.dmark
@@ -1,69 +1,69 @@
-h1. D★Mark
+#h1 D★Mark
 
-p. %firstterm{D★Mark} is a language for marking up prose. It facilitates writing semantically meaningful text, without limiting itself to the semantics provided by HTML or Markdown. If you’re a technical writer looking for a flexible markup language, D★Mark might be a good fit.
+#p %firstterm{D★Mark} is a language for marking up prose. It facilitates writing semantically meaningful text, without limiting itself to the semantics provided by HTML or Markdown. If you’re a technical writer looking for a flexible markup language, D★Mark might be a good fit.
 
-p. Here’s an example of D★Mark:
+#p Here’s an example of D★Mark:
 
-listing.
-  para%. This a paragraph; an element in block form containing some text.
+#listing
+  %#para This a paragraph; an element in block form containing some text.
 
-  note[only=web]%. This is a note that will %%emph{only%} show up on web.
+  %#note[only=web] This is a note that will %%emph{only%} show up on web.
 
-p. For development details on D★Mark, see %link[target=https://github.com/ddfreyne/d-mark]{its GitHub repository}. Please %link[target=https://github.com/ddfreyne/d-mark/issues/new]{open an issue} for any problems that you find.
+#p For development details on D★Mark, see %link[target=https://github.com/ddfreyne/d-mark]{its GitHub repository}. Please %link[target=https://github.com/ddfreyne/d-mark/issues/new]{open an issue} for any problems that you find.
 
-h2. Goals
+#h2 Goals
 
-dl.
-  dt. Be extensible
-  dd. Define only the syntax of the markup language, and don’t bother with semantics. Do not define a vocabulary.
+#dl
+  #dt Be extensible
+  #dd Define only the syntax of the markup language, and don’t bother with semantics. Do not define a vocabulary.
 
-  dt. Be simple
-  dd. Be easy to write, easy to read, and easy to parse. Be unambiguous. Be easy to syntax highlight.
+  #dt Be simple
+  #dd Be easy to write, easy to read, and easy to parse. Be unambiguous. Be easy to syntax highlight.
 
-  dt. Be compact
-  dd. Introduce as little extra syntax as possible.
+  #dt Be compact
+  #dd Introduce as little extra syntax as possible.
 
-h2. Syntax
+#h2 Syntax
 
-p. D★Mark knows two constructs: %firstterm{elements} and %firstterm{text}. An element has a name, attributes, and wraps elements and/or text in order to give them meaning. Text is just that—text.
+#p D★Mark knows two constructs: %firstterm{elements} and %firstterm{text}. An element has a name, attributes, and wraps elements and/or text in order to give them meaning. Text is just that—text.
 
-p. An element in D★Mark can take two forms %firstterm{block-level} and %firstterm{inline}:
+#p An element in D★Mark can take two forms %firstterm{block-level} and %firstterm{inline}:
 
-dl.
-  dt. Block form
-  dd.
-    p. An element in block form consists of the name of the element, a period, optionally attributes enclosed in rectangular brackets, a space character, and finally the content. For example:
+#dl
+  #dt Block form
+  #dd
+    #p An element in block form consists of the %code{#} symbol, the name of the element, optionally attributes enclosed in rectangular brackets, a space character, and finally the content. For example:
 
-    listing.
-      para%. This a paragraph; an element in block form containing some text.
+    #listing
+      %#para This a paragraph; an element in block form containing some text.
 
-      note[only=web]%. This is an example “note” element with an “only” attribute.
+      %#note[only=web] This is an example “note” element with an “only” attribute.
 
-  dt. Inline form
-  dd.
-    p. Inside an element, text can be marked up using elements with the inline form. An element in inline form consists of a percentage sign, the name of the element, optionally attributes enclosed in rectangular brackets, and finally the content within braces. For example:
+  #dt Inline form
+  #dd
+    #p Inside an element, text can be marked up using elements with the inline form. An element in inline form consists of the %code{%%} symbol, the name of the element, optionally attributes enclosed in rectangular brackets, and finally the content within braces. For example:
 
-    listing.
-      para%. I am a paragraph with an %%emph{amazing%} inline element.
+    #listing
+      %#para I am a paragraph with an %%emph{amazing%} inline element.
 
-p. An element name starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{emph}, %code{h2}, and %code{section-header} are valid element names, while %code{SectionHeader}, %code{2} and %code{input_data} are not.
+#p An element name starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{emph}, %code{h2}, and %code{section-header} are valid element names, while %code{SectionHeader}, %code{2} and %code{input_data} are not.
 
-note. The restrictions on what can be an element name will likely be relaxed before the 1.0 release.
+#note The restrictions on what can be an element name will likely be relaxed before the 1.0 release.
 
-p. At the top level, D★Mark documents consists %emph{only} of elements in block form.
+#p At the top level, D★Mark documents consists %emph{only} of elements in block form.
 
-p. Elements in block form can be nested. To do so, indent the nested block two spaces deeper than the enclosing block. For example, the following defines a %code{list} element with three %code{item} elements inside it:
+#p Elements in block form can be nested. To do so, indent the nested block two spaces deeper than the enclosing block. For example, the following defines a %code{list} element with three %code{item} elements inside it:
 
-listing.
-  list[unordered]%.
-    item%. glob patterns
-    item%. regular expression patterns
-    item%. legacy patterns
+#listing
+  %#list[unordered]
+    %#item glob patterns
+    %#item regular expression patterns
+    %#item legacy patterns
 
-p. The block element form can also include text on indented lines following the element. In this case, the content is not wrapped inside a nested block-level element. This is particularly useful for source code listing. For example:
+#p The block element form can also include text on indented lines following the element. In this case, the content is not wrapped inside a nested block-level element. This is particularly useful for source code listing. For example:
 
-listing.
-  listing[lang=ruby]%.
+#listing
+  %#listing[lang=ruby]
     identifier = Nanoc::Identifier.new('/about.md')
 
     identifier.without_ext
@@ -72,134 +72,146 @@ listing.
     identifier.ext
     # => "md"
 
-p. An element in block form can always be expressed in inline form and vice versa, with the exception of a top-level element, which always needs to be in block form.
+#p An element in block form can always be expressed in inline form and vice versa, with the exception of a top-level element, which always needs to be in block form.
 
-h3. Attributes
+#h3 Attributes
 
-p. Both block and inline elements can also have attributes. Attributes are enclosed in square brackets after the element name, as a comma-separated list of key-value pairs separated by an equal sign. The value part, along with the equal sign, can be omitted, in which case the value will be equal to the key name.
+#p Both block and inline elements can also have attributes. Attributes are enclosed in square brackets after the element name, as a comma-separated list of key-value pairs separated by an equal sign. The value part, along with the equal sign, can be omitted, in which case the value will be equal to the key name.
 
-p. For example:
+#p For example:
 
-ul.
-  li.
-    p. %code{%%code[lang=ruby]{Nanoc::VERSION%}} is an inline %code{code} element with the %code{lang} attribute set to %code{ruby}.
+#ul
+  #li
+    #p %code{%%code[lang=ruby]{Nanoc::VERSION%}} is an inline %code{code} element with the %code{lang} attribute set to %code{ruby}.
 
-  li.
-    p. %code{%%only[web]{Refer to the release notes for details.%}} is an inline %code{only} element with the %code{web} attribute set to %code{web}.
+  #li
+    #p %code{%%only[web]{Refer to the release notes for details.%}} is an inline %code{only} element with the %code{web} attribute set to %code{web}.
 
-  li.
-    p. %code{h2[id=donkey]. All about donkeys} is a block-level %code{h2} element with the %code{id} attribute set to %code{donkey}.
+  #li
+    #p %code{#h2[id=donkey] All about donkeys} is a block-level %code{h2} element with the %code{id} attribute set to %code{donkey}.
 
-  li.
-    p. %code{p[print]. This is a paragraph that only readers of the book will see.} is a block-level %code{para} element with the %code{print} attribute set to %code{print}.
+  #li
+    #p %code{#p[print] This is a paragraph that only readers of the book will see.} is a block-level %code{para} element with the %code{print} attribute set to %code{print}.
 
-p. An attribute key starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{lang} and %code{only-for} are valid attribute keys, while %code{OnlyFor} and %code{data_type} are not.
+#p An attribute key starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{lang} and %code{only-for} are valid attribute keys, while %code{OnlyFor} and %code{data_type} are not.
 
-note. The restrictions on what can be an attribute key will likely be relaxed before the 1.0 release.
+#note The restrictions on what can be an attribute key will likely be relaxed before the 1.0 release.
 
-h3. Escaping
+#h3 Escaping
 
-p. The following characters need to be escaped:
+#p The following characters need to be escaped:
 
-ul.
-  li. %code{%}}
-  li. %code{%%}
-  li. %code{,} (only within attribute values)
-  li. %code{]} (only within attribute values)
+#ul
+  #li %code{%}}
+  #li %code{%%}
+  #li %code{#} (only at the beginning of a block)
+  #li %code{,} (only within attribute values)
+  #li %code{]} (only within attribute values)
 
-p. To escape a character, prefix it with %code{%%}. Thus, %code{%%%%} is the escaped form of %code{%%}, and %code{%%%}} is the escaped form of %code{%}}. For example:
+#p To escape a character, prefix it with %code{%%}.
 
-listing.
-  para [kind=joke%%, ha ha]. They say 20%% of all statistics are made up.
+#p The following is an example of escaping inline content:
 
-p. This is a %code{para} element with the %code{kind} set to %code{joke, ha ha}, and the content “They say 20%% of all statistics are made up.”
+#listing
+  %#p To escape a character, prefix it with %%code{%%%%%}.
 
-h2. Comparison with other languages
+#p The following is a listing element containing escaped D★Mark:
 
-p. D★Mark takes inspiration from a variety of other languages.
+#listing
+  %#listing
+    %%#para This is a paragraph element in block form.
 
-dl.
-  dt. HTML
-  dd.
-    p. HTML is syntactically unambiguous, but comparatively more verbose than other languages. It also prescribes only a small set of elements, which makes it awkward to use for prose that requires more thorough markup. It is possible use %code{span} or %code{div} elements with custom classes, but this approach turns an already verbose language into something even more verbose.
+#p Here’s an example of escaped characters in an attribute value:
 
-    listing[lang=html].
+#listing
+  %#para[kind=joke%%, ha ha] They say 20%%%% of all statistics are made up.
+
+#h2 Comparison with other languages
+
+#p D★Mark takes inspiration from a variety of other languages.
+
+#dl
+  #dt HTML
+  #dd
+    #p HTML is syntactically unambiguous, but comparatively more verbose than other languages. It also prescribes only a small set of elements, which makes it awkward to use for prose that requires more thorough markup. It is possible use %code{span} or %code{div} elements with custom classes, but this approach turns an already verbose language into something even more verbose.
+
+    #listing[lang=html]
       <p>A glob pattern that matches every item is <span class="pattern attr-kind-glob">/**/*</span>.</p>
 
-    listing[lang=d-mark].
-      para%. A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
+    #listing[lang=d-mark]
+      %#para A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
 
-  dt. XML
-  dd.
-    p. Similar to HTML, with the major difference that XML does not prescribe a set of elements.
+  #dt XML
+  #dd
+    #p Similar to HTML, with the major difference that XML does not prescribe a set of elements.
 
-    listing[lang=xml].
+    #listing[lang=xml]
       <para>A glob pattern that matches every item is <pattern kind="glob">/**/*</pattern>.</para>
 
-    listing[lang=d-mark].
-      para%. A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
+    #listing[lang=d-mark]
+      %#para A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
 
-  dt. Markdown
-  dd.
-    p. Markdown has a compact syntax, but is complex and ambiguous, as evidenced by the many different mutually incompatible implementations. It prescribes a small set of elements (smaller even than HTML). It supports embedding raw HTML, which in theory makes it possible to combine the best of both worlds, but in practice leads to markup that is harder to read than either Markdown or HTML separately, and occasionally trips up the parser and syntax highlighter.
+  #dt Markdown
+  #dd
+    #p Markdown has a compact syntax, but is complex and ambiguous, as evidenced by the many different mutually incompatible implementations. It prescribes a small set of elements (smaller even than HTML). It supports embedding raw HTML, which in theory makes it possible to combine the best of both worlds, but in practice leads to markup that is harder to read than either Markdown or HTML separately, and occasionally trips up the parser and syntax highlighter.
 
-    listing[lang=markdown].
+    #listing[lang=markdown]
       A glob pattern that matches every item is <span class="glob attr-kind-glob">/**/*</span>.
 
-    listing[lang=d-mark].
-      para%. A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
+    #listing[lang=d-mark]
+      %#para A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
 
-  dt. AsciiDoc
-  dd.
-    p. AsciiDoc, along with its AsciiDoctor variant, are syntactically unambiguous, but complex languages. They prescribe a comparatively large set of elements which translates well to DocBook and HTML. They do not support custom markup or embedding raw HTML, which makes them harder t use for prose that requires more complex markup.
+  #dt AsciiDoc
+  #dd
+    #p AsciiDoc, along with its AsciiDoctor variant, are syntactically unambiguous, but complex languages. They prescribe a comparatively large set of elements which translates well to DocBook and HTML. They do not support custom markup or embedding raw HTML, which makes them harder t use for prose that requires more complex markup.
 
-    note. There is no AsciiDoc example, as this example cannot be represented with AsciiDoc.
+    #note There is no AsciiDoc example, as this example cannot be represented with AsciiDoc.
 
-  dt. TeX, LaTeX
-  dd.
-    p. TeX is a turing-complete programming language, as opposed to a markup language, intended for typesetting. This makes it impractical for using it as the source for converting it to other formats. Its syntax is simple and compact, and served as an inspiration for D★Mark.
+  #dt TeX, LaTeX
+  #dd
+    #p TeX is a turing-complete programming language, as opposed to a markup language, intended for typesetting. This makes it impractical for using it as the source for converting it to other formats. Its syntax is simple and compact, and served as an inspiration for D★Mark.
 
-    listing[lang=latex].
+    #listing[lang=latex]
       A glob pattern that matches every item is \pattern[glob]{/**/*%}.
 
-    listing[lang=d-mark].
-      para%. A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
+    #listing[lang=d-mark]
+      %#para A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
 
-  dt. JSON, YAML
-  dd.
-    p. JSON and YAML are data interchange formats rather than markup languages, and thus are not well-suited for marking up prose.
+  #dt JSON, YAML
+  #dd
+    #p JSON and YAML are data interchange formats rather than markup languages, and thus are not well-suited for marking up prose.
 
-    listing[lang=json].
+    #listing[lang=json]
       [
         "A glob pattern that matches every item is ",
         ["pattern", {"kind": "glob"%}, ["/**/*"]],
         "."
       ]
 
-    listing[lang=d-mark].
-      para%. A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
+    #listing[lang=d-mark]
+      %#para A glob pattern that matches every item is %%pattern[glob]{/**/*%}.
 
-h2. Samples
+#h2 Samples
 
-p. The %filename{samples/} directory contains some sample D★Mark files. They can be processed by invoking the appropriate script with the same filename. For example:
+#p The %filename{samples/} directory contains some sample D★Mark files. They can be processed by invoking the appropriate script with the same filename. For example:
 
-listing.
+#listing
   %prompt{%%} %kbd{bundle exec ruby samples/trivial.rb}
   <p>I’m a <em>trivial</em> example!</p>
 
-h2. Programmatic usage
+#h2 Programmatic usage
 
-p. Handling a D★Mark file consists of two stages: parsing and translating.
+#p Handling a D★Mark file consists of two stages: parsing and translating.
 
-p. The parsing stage converts text into a list of nodes. Construct a parser with the tokens as input, and call %code{#run} to get the list of nodes.
+#p The parsing stage converts text into a list of nodes. Construct a parser with the tokens as input, and call %code{#run} to get the list of nodes.
 
-listing[lang=ruby].
+#listing[lang=ruby]
   content = File.read(ARGV[0])
   nodes = DMark::Parser.new(content).run
 
-p. The translating stage is not the responsibility of D★Mark. A translator is part of the domain of the source text, and D★Mark only deals with syntax rather than semantics. A translator will run over the tree and convert it into something else (usually another string). To do so, handle each node type (%code{DMark::ElementNode} or %code{String}). For example, the following translator will convert the tree into something that resembles XML:
+#p The translating stage is not the responsibility of D★Mark. A translator is part of the domain of the source text, and D★Mark only deals with syntax rather than semantics. A translator will run over the tree and convert it into something else (usually another string). To do so, handle each node type (%code{DMark::ElementNode} or %code{String}). For example, the following translator will convert the tree into something that resembles XML:
 
-listing[lang=ruby].
+#listing[lang=ruby]
   class MyXMLLikeTranslator < DMark::Translator
     def handle(node)
       case node

--- a/lib/d-mark/parser.rb
+++ b/lib/d-mark/parser.rb
@@ -133,52 +133,12 @@ module DMark
 
     # FIXME: ugly and duplicated
     def try_read_block_start
-      old_pos = @pos
-
-      success =
-        if try_read_identifier_head
-          read_identifier_tail
-
-          if peek_char == '['
-            new_pos = try_read_attributes
-            new_pos && @pos = new_pos
-          end
-
-          case peek_char
-          when '.'
-            advance
-            [' ', "\n", nil].include?(peek_char)
-          when '%'
-            false
-          end
-        end
-
-      @pos = old_pos
-      success
-    end
-
-    # FIXME: ugly and duplicated
-    def try_read_identifier_head
-      char = peek_char
-      case char
-      when 'a'..'z'
-        advance
-        char
+      if peek_char == '#'
+        next_char = peek_char(@pos + 1)
+        ('a'..'z').cover?(next_char)
+      else
+        false
       end
-    end
-
-    # FIXME: ugly and duplicated
-    def try_read_attributes
-      old_pos = @pos
-
-      begin
-        read_attributes
-        @pos
-      rescue
-        nil
-      end
-    ensure
-      @pos = old_pos
     end
 
     def detect_indentation
@@ -206,6 +166,7 @@ module DMark
     end
 
     def read_single_block
+      read_char('#')
       identifier = read_identifier
 
       attributes =
@@ -214,8 +175,6 @@ module DMark
         else
           {}
         end
-
-      read_char('.')
 
       case peek_char
       when nil, "\n"
@@ -393,7 +352,7 @@ module DMark
     def read_percent_body
       char = peek_char
       case char
-      when '%', '}', '.'
+      when '%', '}', '#'
         advance
         char.to_s
       when nil, "\n"

--- a/spec/d-mark/parser_spec.rb
+++ b/spec/d-mark/parser_spec.rb
@@ -9,26 +9,26 @@ end
 describe 'DMark::Parser#parser' do
   it 'parses' do
     expect(parse('')).to eq []
-    expect(parse('p.')).to eq [element('p', {}, [])]
-    expect(parse('p. hi')).to eq [element('p', {}, ['hi'])]
-    expect(parse('p. hi %%')).to eq [element('p', {}, ['hi ', '%'])]
-    expect(parse('p. hi %}')).to eq [element('p', {}, ['hi ', '}'])]
+    expect(parse('#p')).to eq [element('p', {}, [])]
+    expect(parse('#p hi')).to eq [element('p', {}, ['hi'])]
+    expect(parse('#p hi %%')).to eq [element('p', {}, ['hi ', '%'])]
+    expect(parse('#p hi %}')).to eq [element('p', {}, ['hi ', '}'])]
   end
 
   it 'parses escaped % in block' do
-    expect(parse('p. %%')).to eq [
+    expect(parse('#p %%')).to eq [
       element('p', {}, ['%'])
     ]
   end
 
   it 'parses escaped } in block' do
-    expect(parse('p. %}')).to eq [
+    expect(parse('#p %}')).to eq [
       element('p', {}, ['}'])
     ]
   end
 
   it 'parses escaped % in inline block' do
-    expect(parse('p. %foo{%%}')).to eq [
+    expect(parse('#p %foo{%%}')).to eq [
       element(
         'p', {},
         [
@@ -39,7 +39,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses escaped } in inline block' do
-    expect(parse('p. %foo{%}}')).to eq [
+    expect(parse('#p %foo{%}}')).to eq [
       element(
         'p', {},
         [
@@ -49,7 +49,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses block with text and element content' do
-    expect(parse('p. hi %em{ho}')).to eq [
+    expect(parse('#p hi %em{ho}')).to eq [
       element(
         'p', {}, [
           'hi ',
@@ -60,7 +60,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses block with text and element content, followed by newline' do
-    expect(parse("p. hi %em{ho}\n")).to eq [
+    expect(parse("#p hi %em{ho}\n")).to eq [
       element(
         'p', {}, [
           'hi ',
@@ -71,7 +71,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses children' do
-    expect(parse("p. hi %em{ho}\n  p. child p")).to eq [
+    expect(parse("#p hi %em{ho}\n  #p child p")).to eq [
       element(
         'p', {}, [
           'hi ',
@@ -83,7 +83,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses children multiple levels deep' do
-    expect(parse("p. hi %em{ho}\n  p. child p\n    p. subchild p")).to eq [
+    expect(parse("#p hi %em{ho}\n  #p child p\n    #p subchild p")).to eq [
       element(
         'p', {}, [
           'hi ',
@@ -104,7 +104,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'ignores blanks' do
-    expect(parse("p. foo\n \n  p. bar\n  \n\n    p. qux")).to eq [
+    expect(parse("#p foo\n \n  #p bar\n  \n\n    #p qux")).to eq [
       element(
         'p', {}, [
           'foo',
@@ -124,106 +124,104 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'reads multiple consecutive blocks' do
-    expect(parse("p. foo\np. bar")).to eq [
+    expect(parse("#p foo\n#p bar")).to eq [
       element('p', {}, ['foo']),
       element('p', {}, ['bar'])
     ]
   end
 
   it 'includes raw content' do
-    expect(parse("p. foo\n  donkey")).to eq [
+    expect(parse("#p foo\n  donkey")).to eq [
       element('p', {}, %W(foo \n donkey))
     ]
   end
 
   it 'includes raw content including initial indentation' do
-    expect(parse("p. foo\n    donkey")).to eq [
+    expect(parse("#p foo\n    donkey")).to eq [
       element('p', {}, ['foo', "\n", '  donkey'])
     ]
   end
 
   it 'includes raw content from multiple lines' do
-    expect(parse("p. foo\n    donkey\n  giraffe\n    zebra\n")).to eq [
+    expect(parse("#p foo\n    donkey\n  giraffe\n    zebra\n")).to eq [
       element('p', {}, ['foo', "\n", '  donkey', "\n", 'giraffe', "\n", '  zebra'])
     ]
   end
 
   it 'includes empty lines in raw content' do
-    expect(parse("p. foo\n\n  donkey\n\n    giraffe\n")).to eq [
+    expect(parse("#p foo\n\n  donkey\n\n    giraffe\n")).to eq [
       element('p', {}, ['foo', "\n", "\n", 'donkey', "\n", "\n", '  giraffe'])
     ]
   end
 
   it 'does not include line break after empty block element and before data lines' do
-    expect(parse("p.\n  donkey\n")).to eq [
+    expect(parse("#p\n  donkey\n")).to eq [
       element('p', {}, ['donkey'])
     ]
   end
 
   it 'parses inline element in data lines' do
-    expect(parse("p.\n  %emph{donkey}\n")).to eq [
-      element('p', {}, [
-                element('emph', {}, ['donkey'])
-              ])
+    expect(parse("#p\n  %emph{donkey}")).to eq [
+      element('p', {}, [element('emph', {}, ['donkey'])])
     ]
   end
 
   it 'parses empty attributes' do
-    expect(parse('p[]. hi')).to eq [
+    expect(parse('#p[] hi')).to eq [
       element('p', {}, ['hi'])
     ]
   end
 
   it 'parses single attribute' do
-    expect(parse('p[foo=bar]. hi')).to eq [
+    expect(parse('#p[foo=bar] hi')).to eq [
       element('p', { 'foo' => 'bar' }, ['hi'])
     ]
   end
 
   it 'parses single value-less attribute' do
-    expect(parse('p[foo]. hi')).to eq [
+    expect(parse('#p[foo] hi')).to eq [
       element('p', { 'foo' => 'foo' }, ['hi'])
     ]
   end
 
   it 'parses multiple attributes' do
-    expect(parse('p[foo=bar,qux=donkey]. hi')).to eq [
+    expect(parse('#p[foo=bar,qux=donkey] hi')).to eq [
       element('p', { 'foo' => 'bar', 'qux' => 'donkey' }, ['hi'])
     ]
   end
 
   it 'parses multiple value-less attributes' do
-    expect(parse('p[foo,qux]. hi')).to eq [
+    expect(parse('#p[foo,qux] hi')).to eq [
       element('p', { 'foo' => 'foo', 'qux' => 'qux' }, ['hi'])
     ]
   end
 
   it 'parses escaped attributes' do
-    expect(parse('p[foo=%],bar=%%,donkey=%,]. hi')).to eq [
+    expect(parse('#p[foo=%],bar=%%,donkey=%,] hi')).to eq [
       element('p', { 'foo' => ']', 'bar' => '%', 'donkey' => ',' }, ['hi'])
     ]
   end
 
   it 'parses attributes in empty block' do
-    expect(parse("p[foo=bar].\n  hi")).to eq [
+    expect(parse("#p[foo=bar]\n  hi")).to eq [
       element('p', { 'foo' => 'bar' }, ['hi'])
     ]
   end
 
   it 'parses block start on next line properly' do
-    expect(parse("p.\n  this is not a child block.")).to eq [
+    expect(parse("#p\n  this is not a child block.")).to eq [
       element('p', {}, ['this is not a child block.'])
     ]
   end
 
   it 'parses block start on next line with spacey' do
-    expect(parse("p.\n  foo.bar")).to eq [
+    expect(parse("#p\n  foo.bar")).to eq [
       element('p', {}, ['foo.bar'])
     ]
   end
 
   it 'parses child block without content' do
-    expect(parse("ul.\n  li.\n    p. You can.")).to eq [
+    expect(parse("#ul\n  #li\n    #p You can.")).to eq [
       element(
         'ul', {},
         [
@@ -239,7 +237,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses child block without content at end' do
-    expect(parse("ul.\n  li.")).to eq [
+    expect(parse("#ul\n  #li")).to eq [
       element(
         'ul', {},
         [
@@ -250,7 +248,7 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses child block with attributes' do
-    expect(parse("ul.\n  li[foo].")).to eq [
+    expect(parse("#ul\n  #li[foo]")).to eq [
       element(
         'ul', {},
         [
@@ -261,54 +259,55 @@ describe 'DMark::Parser#parser' do
   end
 
   it 'parses document starting with blank lines' do
-    expect(parse("  \n \np. Hi!")).to eq [
+    expect(parse("  \n \n#p Hi!")).to eq [
       element('p', {}, ['Hi!'])
     ]
   end
 
   it 'parses escaped indented line' do
-    expect(parse("listing.\n  h1%. Foo\n")).to eq [
-      element('listing', {}, ['h1', '.', ' Foo'])
+    expect(parse("#listing\n  %#h1 Foo\n")).to eq [
+      element('listing', {}, ['#', 'h1 Foo'])
     ]
   end
 
   it 'parses escaped indented line with attributes' do
-    expect(parse("listing.\n  h1[donkey]%. Foo\n")).to eq [
-      element('listing', {}, ['h1[donkey]', '.', ' Foo'])
+    expect(parse("#listing\n  %#h1[donkey] Foo\n")).to eq [
+      element('listing', {}, ['#', 'h1[donkey] Foo'])
     ]
   end
 
   it 'does not parse percent escapes' do
-    expect { parse('p. %ref[url=https://github.com/pulls?q=is%3Aopen+user%3Ananoc]{eek}') }
+    expect { parse('#p %ref[url=https://github.com/pulls?q=is%3Aopen+user%3Ananoc]{eek}') }
       .to raise_error(DMark::Parser::ParserError, 'parse error at line 1, col 43: expected "%", "," or "]" after "%", but got "3"')
   end
 
   it 'does not parse attribute values ending with an end-of-file' do
-    expect { parse('p. %ref[url=hello') }
+    expect { parse('#p %ref[url=hello') }
       .to raise_error(DMark::Parser::ParserError, 'parse error at line 1, col 18: unexpected file end in attribute value')
   end
 
   it 'does not parse attribute values ending with a line break' do
-    expect { parse("p. %ref[url=hello\n") }
+    expect { parse("#p %ref[url=hello\n") }
       .to raise_error(DMark::Parser::ParserError, 'parse error at line 1, col 18: unexpected line break in attribute value')
   end
 
   it 'does not parse escaped attribute values ending with an end-of-file' do
-    expect { parse('p. %ref[url=hello%') }
+    expect { parse('#p %ref[url=hello%') }
       .to raise_error(DMark::Parser::ParserError, 'parse error at line 1, col 19: unexpected file end in attribute value')
   end
 
   it 'does not parse escaped attribute values ending with a line break' do
-    expect { parse("p. %ref[url=hello%\n") }
+    expect { parse("#p %ref[url=hello%\n") }
       .to raise_error(DMark::Parser::ParserError, 'parse error at line 1, col 19: unexpected line break in attribute value')
   end
 
   it 'does not parse' do
+    expect { parse('#') }.to raise_error(DMark::Parser::ParserError)
     expect { parse('p') }.to raise_error(DMark::Parser::ParserError)
     expect { parse('0') }.to raise_error(DMark::Parser::ParserError)
     expect { parse('p0') }.to raise_error(DMark::Parser::ParserError)
-    expect { parse('0.') }.to raise_error(DMark::Parser::ParserError)
-    expect { parse('p. %') }.to raise_error(DMark::Parser::ParserError)
-    expect { parse('p. }') }.to raise_error(DMark::Parser::ParserError)
+    expect { parse('#0') }.to raise_error(DMark::Parser::ParserError)
+    expect { parse('#p %') }.to raise_error(DMark::Parser::ParserError)
+    expect { parse('#p }') }.to raise_error(DMark::Parser::ParserError)
   end
 end


### PR DESCRIPTION
This is a *breaking* change which converts the block form of elements from name + `.` to `#` + name. For example,

```
para. Hello world!
```

becomes

```
#para Hello world!
```

### Need

This change is necessary in order to make it possible to escape elements in block-form in inline content. For example:

```
#listing[lang=ruby]
  %#para Hello world!
```

Currently, an element in block form can be escaped by escaping the `.`, but this leads to a confusing syntax:

```
listing[lang=ruby].
  para%. Hello world!
```

It gets even more confusing with an element that has attributes, as it is unintuitive how the escaping works:

```
listing[lang=ruby].
  para[only=web]%. Hello world!
```

(This example does not even work, as escaping a block-form element with attributes is not supported.)

### Alternatives

An alternative syntax for the block form, in which the start character is `%` rather than `#`, was considered but deemed to be impractical, as this approach makes it harder (though not impossible) to distinguish between an element in block form, and an element in inline form. For example, the following would be harder to parse (and arguably understand) if block form were to be indicated with `#` rather than `%`:

```
#listing
  %prompt{%%} ls
```

I will attempt to replace `#` with `%` in order to reduce the syntactic weight, as currently the number of characters that carry syntacting meaning is rather large (`%`, `#`, `{`, `}`, `[`, `]`, and, only inside attributes, `=` and `,`).