### PR TITLE
Add audience element

### DIFF
--- a/doc.dmark
+++ b/doc.dmark
@@ -2,6 +2,12 @@
 
 #p %firstterm{D★Mark} is a language for marking up prose. It facilitates writing semantically meaningful text, without limiting itself to the semantics provided by HTML or Markdown. If you’re a technical writer looking for a flexible markup language, D★Mark might be a good fit.
 
+#audience[only=ursula]
+  #p This paragraph is only for Ursula.
+
+#audience[except=ursula]
+  #p I’m conviced this is a badly written paragraph and my ask is to remove it.
+
 #p Here’s an example of D★Mark:
 
 #listing

--- a/samples/doc2html.rb
+++ b/samples/doc2html.rb
@@ -158,6 +158,16 @@ class Doc2HTML < DMark::Translator
       case node.name
       when 'p', 'dl', 'dt', 'dd', 'ol', 'ul', 'li', 'code', 'kbd'
         wrap(node.name) { handle_children(node, depths) }
+      when 'audience'
+        if node.attributes['only']
+          if node.attributes['only'].split(';').include?(ENV['AUDIENCE'])
+            handle_children(node, depths)
+          end
+        elsif node.attributes['except']
+          unless node.attributes['except'].split(';').include?(ENV['AUDIENCE'])
+            handle_children(node, depths)
+          end
+        end
       when 'h'
         depth = depths.fetch('section', 0) + 1
         wrap("h#{depth}") { handle_children(node, depths) }


### PR DESCRIPTION
`only` and `except` seem extraneous to me. Why not `audience="instructor"`, where `instructor` is handled via a Makefile or alternative.