### PR TITLE
Make translator immutable

### DIFF
--- a/lib/d-mark/translator.rb
+++ b/lib/d-mark/translator.rb
@@ -19,19 +19,12 @@ module DMark
       end
     end
 
-    attr_reader :out
-
     def initialize(nodes)
       @nodes = nodes
-
-      @out = ''
     end
 
     def run
-      @nodes.each do |node|
-        handle(node)
-      end
-      @out
+      [@nodes.map { |node| handle(node) }].flatten.join('')
     end
 
     def handle(node, path = [])
@@ -59,7 +52,7 @@ module DMark
 
     def handle_children(node, path)
       new_path = path + [node]
-      node.children.each { |child| handle(child, new_path) }
+      node.children.map { |child| handle(child, new_path) }
     end
   end
 end

--- a/site/content/index.dmark
+++ b/site/content/index.dmark
@@ -286,13 +286,15 @@ title: D★Mark
   #listing[lang=ruby]
     class MyXMLLikeTranslator < DMark::Translator
       def handle_string(string)
-        out << escape(string)
+        [escape(string)]
       end
 
       def handle_element(element, path)
-        out << "<#{node.name%}>"
-        handle_children(node, path)
-        out << "</#{node.name%}>"
+        [
+          "<#{node.name%}>",
+          handle_children(node, path),
+          "</#{node.name%}>",
+        ]
       end
 
       def escape(string)
@@ -303,16 +305,16 @@ title: D★Mark
     result = MyXMLLikeTranslator.new(nodes).run
     puts result
 
-  #p To create a translator, create a subclass of %code{DMark::Translator}, and implement %code{#handle_string} and %code{#handle_element}, which should write their translated content to %code{out}.
+  #p To create a translator, create a subclass of %code{DMark::Translator}, and implement %code{#handle_string} and %code{#handle_element}, which should return an (optionally nested) array of strings, which will then be joined into a single string after processing.
 
   #dl
     #dt %code{#handle_string(string)}
     #dd
-      #p This convert plain strings. The %code{string} argument is the string to convert. Typically, this copies the string to the output using %code{out << escape(string)}, where the %code{#escape} function performs escaping (such as replacing %code{&} and %code{<} with %code{&amp;} and %code{&lt;} in HTML and XML).
+      #p This convert plain strings. The %code{string} argument is the string to convert. Typically, this returns an array with the escaped string, e.g. %code{[escape(string)]}, where the %code{#escape} function performs escaping (such as replacing %code{&} and %code{<} with %code{&amp;} and %code{&lt;} in HTML and XML).
 
     #dt %code{#handle_element(element, path)}
     #dd
-      #p This converts elements. The %code{element} argument is the element to convert, and %code{path} is an array containing the ancestors of this element, starting with the root. Like with strings, this function also writes translated content to %code{out} using the %code{#<<} method.
+      #p This converts elements. The %code{element} argument is the element to convert, and %code{path} is an array containing the ancestors of this element, starting with the root.
 
       #p The way an element is translated often depends on the element name, %code{element.name} (a string), and might depend on the element’s attributes, %code{element.attributes} (a hash).
 
@@ -325,7 +327,9 @@ title: D★Mark
           case element.name
           when 'h'
             depth = path.count { |ancestor| ancestor.name == 'section' %} + 1
-            out << "<h#{depth%}">
-            handle_children(element, path)
-            out << "</h#{depth%}">
+            [
+              "<h#{depth%}>",
+              handle_children(element, path),
+              "</h#{depth%}>",
+            ]
           # … handle other elements here …

--- a/spec/d-mark/translator_spec.rb
+++ b/spec/d-mark/translator_spec.rb
@@ -7,7 +7,10 @@ describe DMark::Translator do
       DMark::ElementNode.new(
         'para',
         { 'only' => 'web', 'animal' => 'donkey' },
-        ['Hi!']
+        [
+          DMark::ElementNode.new('emph', {}, ['Hello']),
+          ' world!'
+        ]
       )
     ]
   end
@@ -25,20 +28,22 @@ describe DMark::Translator do
       let(:translator_class) do
         Class.new(described_class) do
           def handle_string(string)
-            out << string
+            [string]
           end
 
           def handle_element(element, path)
-            out << "<#{element.name}"
-            out << element.attributes.map { |k, v| ' ' + [k, v].join('=') }.join
-            out << '>'
-            handle_children(element, path)
-            out << "</#{element.name}>"
+            [
+              "<#{element.name}",
+              element.attributes.map { |k, v| ' ' + [k, v].join('=') }.join,
+              '>',
+              handle_children(element, path),
+              "</#{element.name}>"
+            ]
           end
         end
       end
 
-      it { is_expected.to eql('<para only=web animal=donkey>Hi!</para>') }
+      it { is_expected.to eql('<para only=web animal=donkey><emph>Hello</emph> world!</para>') }
     end
   end
 end


### PR DESCRIPTION
This makes it possible to capture content and do some inline processing, such as performing syntax highlighting.

I’ve opted for letting `#handle_element` and `#handle_string` return an array of strings instead, which makes it more efficient to concatenate in the end.

* [x] Update tests
* [x] Update documentation