### PR TITLE
Remove translator state

### DIFF
--- a/lib/d-mark/translator.rb
+++ b/lib/d-mark/translator.rb
@@ -19,12 +19,16 @@ module DMark
       end
     end
 
-    def initialize(nodes)
-      @nodes = nodes
+    def self.translate(nodes)
+      new.translate(nodes)
     end
 
-    def run
-      [@nodes.map { |node| handle(node) }].flatten.join('')
+    def translate(nodes, path = [])
+      [nodes.map { |node| handle(node, path) }].flatten.join('')
+    end
+
+    def translate_children(node, path)
+      translate(node.children, path + [node])
     end
 
     def handle(node, path = [])

--- a/site/content/index.dmark
+++ b/site/content/index.dmark
@@ -310,44 +310,48 @@ title: D★Mark
   #dl
     #dt %code{#handle_string(string)}
     #dd
-      #p This convert plain strings. The %code{string} argument is the string to convert. Typically, this returns an array with the escaped string, e.g. %code{[escape(string)]}, where the %code{#escape} function performs escaping (such as replacing %code{&} and %code{<} with %code{&amp;} and %code{&lt;} in HTML and XML).
+      #p This function translates strings. The %code{string} argument is the string to convert. Typically, this returns an array with the escaped string, e.g. %code{[escape(string)]}, where the %code{#escape} function performs escaping (such as replacing %code{&} and %code{<} with %code{&amp;} and %code{&lt;} in HTML and XML).
 
     #dt %code{#handle_element(element, path)}
     #dd
-      #p This converts elements. The %code{element} argument is the element to convert, and %code{path} is an array containing the ancestors of this element, starting with the root.
+      #p This function translates elements. The %code{element} argument is the element to convert, and %code{path} is an array containing the ancestors of this element, starting with the root.
 
       #p The way an element is translated often depends on the element name, %code{element.name} (a string), and might depend on the element’s attributes, %code{element.attributes} (a hash).
 
       #p When handling an element, make sure to handle all its child elements. The built-in %code{#handle_children} function can be used for this, and is typically called like %code{handle_children(element, path)}. Handling child elements does not happen automatically, in order to provide the possibility of conditional output.
 
-      #p The %code{path} argument is useful in cases where the resulting output depends on the nesting level. For example, this page uses nested %code{section} elements that start with a %code{h} (header) element, which is translated to any of the HTML header elements (such as %code{h1}) depending on the number of %code{section} ancestors:
+  #section %h{Tips and tricks}
+    #p The %code{path} argument of %code{#handle_element} is useful in cases where the resulting output depends on the nesting level. For example, this page uses nested %code{section} elements that start with a %code{h} (header) element, which is translated to any of the HTML header elements (such as %code{h1}) depending on the number of %code{section} ancestors:
 
-      #listing[lang=ruby]
-        def handle_element(element, path)
-          case element.name
-          when 'h'
-            depth = path.count { |ancestor| ancestor.name == 'section' %} + 1
-            [
-              "<h#{depth%}>",
-              handle_children(element, path),
-              "</h#{depth%}>",
-            ]
-          # … handle other elements here …
+    #listing[lang=ruby]
+      def handle_element(element, path)
+        case element.name
+        when 'h'
+          depth = path.count { |ancestor| ancestor.name == 'section' %} + 1
+          [
+            "<h#{depth%}>",
+            handle_children(element, path),
+            "</h#{depth%}>",
+          ]
+        # … handle other elements here …
 
-      #p It can be useful to do some further processing on child nodes before returning them. To get a string containing translated child nodes’ content, call %code{#translate_children}, passing in the element containing the children, along with the path. Here is an example of this function being used to syntax-highlight source code listings:
+    #p It can be useful to do some further processing on child nodes before returning them. To get a string containing translated child nodes’ content, call %code{#translate_children}, passing in the element containing the children, along with the path. Here is an example of this function being used to syntax-highlight source code listings:
 
-      #listing[lang=ruby]
-        def handle_element(element, path)
-          case element.name
-          when 'listing'
-            [
-              '<pre><code>',
-              syntax_highlight(translate_children(element, path)),
-              '</code></pre>',
-            ]
-          # … handle other elements here …
-        end
+    #listing[lang=ruby]
+      def handle_element(element, path)
+        case element.name
+        when 'listing'
+          [
+            '<pre><code>',
+            syntax_highlight(element, path),
+            '</code></pre>',
+          ]
+        # … handle other elements here …
+      end
 
-        def syntax_highlight(string, language)
-          # … implmentation here …
-        end
+      def syntax_highlight(element, path)
+        content = translate_children(element, path)
+        language = element.attributes['lang']
+
+        # … implementation here …
+      end

--- a/site/content/index.dmark
+++ b/site/content/index.dmark
@@ -302,7 +302,7 @@ title: D★Mark
       end
     end
 
-    result = MyXMLLikeTranslator.new(nodes).run
+    result = MyXMLLikeTranslator.translate(nodes)
     puts result
 
   #p To create a translator, create a subclass of %code{DMark::Translator}, and implement %code{#handle_string} and %code{#handle_element}, which should return an (optionally nested) array of strings, which will then be joined into a single string after processing.
@@ -333,3 +333,21 @@ title: D★Mark
               "</h#{depth%}>",
             ]
           # … handle other elements here …
+
+      #p It can be useful to do some further processing on child nodes before returning them. To get a string containing translated child nodes’ content, call %code{#translate_children}, passing in the element containing the children, along with the path. Here is an example of this function being used to syntax-highlight source code listings:
+
+      #listing[lang=ruby]
+        def handle_element(element, path)
+          case element.name
+          when 'listing'
+            [
+              '<pre><code>',
+              syntax_highlight(translate_children(element, path)),
+              '</code></pre>',
+            ]
+          # … handle other elements here …
+        end
+
+        def syntax_highlight(string, language)
+          # … implmentation here …
+        end

--- a/site/lib/dmark2html.rb
+++ b/site/lib/dmark2html.rb
@@ -45,7 +45,7 @@ class Doc2HTML < DMark::Translator
     when 'listing'
       wrap('pre') do
         wrap('code') do
-          addition = [handle_children(element, path)].flatten.join
+          addition = translate(element.children, path)
 
           if element.attributes['lang']
             formatter = ::Rouge::Formatters::HTML.new(wrap: false)
@@ -91,6 +91,6 @@ Class.new(Nanoc::Filter) do
 
   def run(content, params = {})
     tree = DMark::Parser.new(content).parse
-    Doc2HTML.new(tree).run
+    Doc2HTML.translate(tree)
   end
 end

--- a/spec/d-mark/translator_spec.rb
+++ b/spec/d-mark/translator_spec.rb
@@ -1,5 +1,5 @@
 describe DMark::Translator do
-  let(:translator) { translator_class.new(nodes) }
+  let(:translator) { translator_class.new }
   let(:translator_class) { described_class }
 
   let(:nodes) do
@@ -15,9 +15,7 @@ describe DMark::Translator do
     ]
   end
 
-  describe '#run' do
-    subject { translator.run }
-
+  shared_examples 'translates' do
     context 'translator base class' do
       it 'raises NotImplementedError' do
         expect { subject }.to raise_error(DMark::Translator::UnhandledNode)
@@ -44,6 +42,51 @@ describe DMark::Translator do
       end
 
       it { is_expected.to eql('<para only=web animal=donkey><emph>Hello</emph> world!</para>') }
+    end
+  end
+
+  describe '.translate' do
+    subject { translator_class.translate(nodes) }
+    include_examples 'translates'
+  end
+
+  describe '#translate' do
+    subject { translator.translate(nodes) }
+    include_examples 'translates'
+  end
+
+  describe '#translate_children' do
+    subject { translator.translate_children(nodes[0], path) }
+    let(:path) { [] }
+
+    context 'translator base class' do
+      it 'raises NotImplementedError' do
+        expect { subject }.to raise_error(DMark::Translator::UnhandledNode)
+      end
+    end
+
+    context 'custom translator' do
+      let(:translator_class) do
+        Class.new(described_class) do
+          def handle_string(string)
+            [string]
+          end
+
+          def handle_element(element, path)
+            attributes = element.attributes.merge(parent: path[-1].name)
+
+            [
+              "<#{element.name}",
+              attributes.map { |k, v| ' ' + [k, v].join('=') }.join,
+              '>',
+              handle_children(element, path),
+              "</#{element.name}>"
+            ]
+          end
+        end
+      end
+
+      it { is_expected.to eql('<emph parent=para>Hello</emph> world!') }
     end
   end
 end


### PR DESCRIPTION
Also adds two convenience methods:

- `Translator.translate(notes)`
- `Translate#translate_children(node, path)`

Fixes #11.