### PR TITLE
Relaxed identifiers

### DIFF
--- a/lib/d-mark/parser.rb
+++ b/lib/d-mark/parser.rb
@@ -209,7 +209,7 @@ module DMark
     def read_identifier_head
       char = peek_char
       case char
-      when 'a'..'z'
+      when 'a'..'z', 'A'..'Z'
         advance
         char
       else
@@ -223,7 +223,7 @@ module DMark
       loop do
         char = peek_char
         case char
-        when 'a'..'z', '-', '0'..'9'
+        when 'a'..'z', 'A'..'Z', '-', '_', '0'..'9'
           advance
           res << char
         else

--- a/site/content/index.dmark
+++ b/site/content/index.dmark
@@ -119,9 +119,7 @@ title: D★Mark
       #listing[lang=d-mark]
         %#para I am a paragraph with an %%em{amazing%} inline element.
 
-  #p An element name starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{em}, %code{h2}, and %code{section-header} are valid element names, while %code{SectionHeader}, %code{2} and %code{input_data} are not.
-
-  #note The restrictions on what can be an element name will likely be relaxed before the 1.0 release.
+  #p An element name starts with a letter (lowercase or uppercase), followed by zero or more letters, digits, dashes, or underscores. For instance, %code{em}, %code{h2}, %code{section-header}, %code{SectionHeader} and %code{section_header} are valid element names, while %code{_section}, %code{2} and %code{hello/world} are not.
 
   #p At the top level, D★Mark documents consists %em{only} of elements in block form.
 
@@ -165,9 +163,7 @@ title: D★Mark
       #li
         #p %code{#p[print] This is a paragraph that only readers of the book will see.} is a block-level %code{para} element with the %code{print} attribute set to %code{print}.
 
-    #p An attribute key starts with a lowercase letter, followed by zero or more lowercase letters, digits or a dash. For instance, %code{lang} and %code{only-for} are valid attribute keys, while %code{OnlyFor} and %code{data_type} are not.
-
-    #note The restrictions on what can be an attribute key will likely be relaxed before the 1.0 release.
+    #p An attribute key starts with a letter (lowercase or uppercase), followed by zero or more letters, digits, dashes, or underscores. For instance, %code{lang}, %code{only-for}, %code{Audience} and %code{data_type} are valid attribute keys, while %code{-except} and %code{hello/world} are not.
 
   #section %h{Escaping}
     #p The following characters need to be escaped:

--- a/spec/d-mark/parser_spec.rb
+++ b/spec/d-mark/parser_spec.rb
@@ -15,6 +15,36 @@ describe 'DMark::Parser#parser' do
     expect(parse('#p hi %}')).to eq [element('p', {}, ['hi ', '}'])]
   end
 
+  it 'parses element with name containing dash' do
+    expect(parse('#intro-para hi')).to eq [
+      element('intro-para', {}, ['hi'])
+    ]
+  end
+
+  it 'parses element with name containing underscore' do
+    expect(parse('#intro_para hi')).to eq [
+      element('intro_para', {}, ['hi'])
+    ]
+  end
+
+  it 'parses element with name containing uppercase letters' do
+    expect(parse('#IntroPara hi')).to eq [
+      element('IntroPara', {}, ['hi'])
+    ]
+  end
+
+  it 'does not parse element with name starting with a dash' do
+    expect { parse('#-intro hi there') }.to raise_error(DMark::Parser::ParserError)
+  end
+
+  it 'does not parse element with name starting with an underscore' do
+    expect { parse('#_intro hi there') }.to raise_error(DMark::Parser::ParserError)
+  end
+
+  it 'does not parse element with name starting with a digit' do
+    expect { parse('#4ever best friends') }.to raise_error(DMark::Parser::ParserError)
+  end
+
   it 'parses escaped % in block' do
     expect(parse('#p %%')).to eq [
       element('p', {}, ['%'])
@@ -177,6 +207,42 @@ describe 'DMark::Parser#parser' do
     expect(parse('#p[foo=bar] hi')).to eq [
       element('p', { 'foo' => 'bar' }, ['hi'])
     ]
+  end
+
+  it 'parses attribute with dash' do
+    expect(parse('#p[intended-audience=learner] hi')).to eq [
+      element('p', { 'intended-audience' => 'learner' }, ['hi'])
+    ]
+  end
+
+  it 'parses attribute with numbers' do
+    expect(parse('#p[is-over-9000=yup] hi')).to eq [
+      element('p', { 'is-over-9000' => 'yup' }, ['hi'])
+    ]
+  end
+
+  it 'parses attribute with underscore' do
+    expect(parse('#p[intended_audience=learner] hi')).to eq [
+      element('p', { 'intended_audience' => 'learner' }, ['hi'])
+    ]
+  end
+
+  it 'parses attribute with uppercase letters' do
+    expect(parse('#p[IntendedAudience=learner] hi')).to eq [
+      element('p', { 'IntendedAudience' => 'learner' }, ['hi'])
+    ]
+  end
+
+  it 'does not parse atttributes starting with -' do
+    expect { parse('#p[-this=is dog] hello yes') }.to raise_error(DMark::Parser::ParserError)
+  end
+
+  it 'does not parse atttributes starting with _' do
+    expect { parse('#p[_this=is dog] hello yes') }.to raise_error(DMark::Parser::ParserError)
+  end
+
+  it 'does not parse atttributes starting with a digit' do
+    expect { parse('#p[4this=is dog] hello yes') }.to raise_error(DMark::Parser::ParserError)
   end
 
   it 'parses single value-less attribute' do


### PR DESCRIPTION
Allows uppercase letters and underscores in identifiers (element names and attribute keys).

Fixes #16.