### PR TITLE
Add ParserError#fancy_message

### DIFF
--- a/lib/d-mark/parser.rb
+++ b/lib/d-mark/parser.rb
@@ -4,18 +4,33 @@ module DMark
       attr_reader :line_nr
       attr_reader :col_nr
 
-      def initialize(line_nr, col_nr, msg)
+      def initialize(line_nr, col_nr, msg, content)
         @line_nr = line_nr
         @col_nr = col_nr
         @msg = msg
+        @content = content
 
         super("parse error at line #{@line_nr + 1}, col #{@col_nr + 1}: #{@msg}")
+      end
+
+      def fancy_message
+        line = @content.lines[line_nr]
+
+        lines = [
+          message,
+          '',
+          line.rstrip,
+          "\e[31m" + ' ' * [col_nr, 0].max + '↑' + "\e[0m"
+        ]
+
+        lines.join("\n")
       end
     end
 
     attr_reader :pos
 
     def initialize(input)
+      @input = input
       @input_chars = input.chars
       @length = @input_chars.size
 
@@ -368,7 +383,7 @@ module DMark
     end
 
     def raise_parse_error(msg)
-      raise ParserError.new(@line_nr, @col_nr, msg)
+      raise ParserError.new(@line_nr, @col_nr, msg, @input)
     end
   end
 end

--- a/site/content/index.dmark
+++ b/site/content/index.dmark
@@ -386,3 +386,19 @@ title: D★Mark
           ]
         # … handle other elements here …
       end
+
+  #section %h{Error handling}
+    #p Parser errors implement %code{#fancy_message}, which is similar to %code{#message} but returns a multi-line string with additional diagnostic information to make it easier to identify and fix errors. For example, the following D★Mark snippet is invalid:
+
+    #listing[lang=d-mark]
+      %#p Stuff
+
+      %#p More stuff %}
+
+    #p … and raises an error, whose %code{#fancy_message} returns a string with this content:
+
+    #listing
+      parse error at line 3, col 15: unexpected %} -- try escaping it as "%%%}"
+
+      %#p More stuff %}
+                    ↑

--- a/spec/d-mark/parser_spec.rb
+++ b/spec/d-mark/parser_spec.rb
@@ -6,6 +6,32 @@ def element(name, attributes, children)
   DMark::ElementNode.new(name, attributes, children)
 end
 
+describe DMark::Parser::ParserError do
+  subject(:error) do
+    begin
+      DMark::Parser.new(content).parse
+    rescue described_class => e
+      break e
+    end
+  end
+
+  let(:content) do
+    "#p Stuff\n\n#p More stuff }"
+  end
+
+  describe '#message' do
+    subject { error.message }
+
+    it { is_expected.to eq('parse error at line 3, col 15: unexpected } -- try escaping it as "%}"') }
+  end
+
+  describe '#fancy_message' do
+    subject { error.fancy_message }
+
+    it { is_expected.to eq("parse error at line 3, col 15: unexpected } -- try escaping it as \"%}\"\n\n#p More stuff }\n\e[31m              ↑\e[0m") }
+  end
+end
+
 describe 'DMark::Parser#parser' do
   it 'parses' do
     expect(parse('')).to eq []


### PR DESCRIPTION
This adds `#fancy_message` to `DMark::Parser::ParserError`, which returns a string with the relevant line from the content, along with an arrow that points to the offense:

```
parse error at line 3, col 15: unexpected } -- try escaping it as "%}"

#p More stuff }
              ↑
```